### PR TITLE
Incorrect namespace mentioned

### DIFF
--- a/helm/templates/webhook-account-binding.yaml
+++ b/helm/templates/webhook-account-binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.app.name }}
-  namespace: {{ .Values.app.name }}
+  namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-admin


### PR DESCRIPTION
The service account was created in the kube-system namespace however, the service account reference in this file is incorrectly pointing to app-monitoring-webhook namespace which does not exist.